### PR TITLE
Add L1 loss & Huber loss to RegressProbe

### DIFF
--- a/libfractal/src/core/CudaKernels.h
+++ b/libfractal/src/core/CudaKernels.h
@@ -101,6 +101,12 @@ namespace cudaKernels
             const cudaStream_t stream);
 
     template<class T>
+    void FuncSignum(const T *_x, const unsigned long ldx,
+            T *_y, const unsigned long ldy,
+            const unsigned long nRows, const unsigned long nCols,
+            const cudaStream_t stream);
+
+    template<class T>
     void FuncSoftmax(const T *_x, const unsigned long ldx,
             T *_y, const unsigned long ldy,
             const unsigned long layerSize, const unsigned long batchSize,

--- a/libfractal/src/core/Engine.cc
+++ b/libfractal/src/core/Engine.cc
@@ -963,6 +963,32 @@ void Engine::FuncRectLinear(Matrix<FLOAT> &X, Matrix<FLOAT> &Y, PStream &stream)
 }
 
 
+void Engine::FuncSignum(Matrix<FLOAT> &X, Matrix<FLOAT> &Y, PStream &stream)
+{
+    verify(X.GetEngine() == this);
+    verify(Y.GetEngine() == this);
+    verify(X.GetNumRows() == Y.GetNumRows());
+    verify(X.GetNumCols() == Y.GetNumCols());
+
+    FLOAT *ptrX, *ptrY;
+
+    ptrX = X.GetPtrForReadWrite(stream);
+    ptrY = Y.GetPtrForWrite(stream);
+
+#ifdef FRACTAL_USE_CUDA
+    SetComputeLoc(stream.loc);
+    cudaKernels::FuncSignum<FLOAT>(ptrX, X.GetLeadingDim(),
+            ptrY, Y.GetLeadingDim(),
+            Y.GetNumRows(), Y.GetNumCols(),
+            stream.cudaStream);
+#else
+    verify(false); /* CPU computation is not supported */
+#endif /* FRACTAL_USE_CUDA */
+
+    Y.FinishWrite(stream);
+}
+
+
 void Engine::FuncSoftmax(Matrix<FLOAT> &X, Matrix<FLOAT> &Y, PStream &stream)
 {
     verify(X.GetEngine() == this);

--- a/libfractal/src/core/Engine.h
+++ b/libfractal/src/core/Engine.h
@@ -139,6 +139,7 @@ public:
     void FuncTanh(Matrix<FLOAT> &X, Matrix<FLOAT> &Y, PStream &stream);
     void FuncSoftplus(Matrix<FLOAT> &X, Matrix<FLOAT> &Y, PStream &stream);
     void FuncRectLinear(Matrix<FLOAT> &X, Matrix<FLOAT> &Y, PStream &stream);
+    void FuncSignum(Matrix<FLOAT> &X, Matrix<FLOAT> &Y, PStream &stream);
     void FuncSoftmax(Matrix<FLOAT> &X, Matrix<FLOAT> &Y, PStream &stream);
     void FuncCTCDecode(Matrix<FLOAT> &X, Matrix<FLOAT> &Y, Matrix<INT> &prevIdxMax, Matrix<INT> &idxMax, const unsigned long nStream, PStream &stream);
     void FuncBoundRange(Matrix<FLOAT> &X, Matrix<FLOAT> &Y, const FLOAT min, const FLOAT max, PStream &stream);

--- a/libfractal/src/probes/RegressProbe.h
+++ b/libfractal/src/probes/RegressProbe.h
@@ -29,7 +29,10 @@ namespace fractal
 class RegressProbe : public TrainableProbe
 {
 public:
-    RegressProbe();
+
+    enum LossType {LOSS_L2, LOSS_L1, LOSS_HUBER};
+
+    RegressProbe(const LossType lossType = LOSS_L2, const FLOAT delta = (FLOAT) 1);
 
     void SetTarget(MultiTypeMatrix &mat, const unsigned long idxFrom, const unsigned long idxTo);
     void ComputeErr(const unsigned long idxFrom, const unsigned long idxTo);
@@ -39,6 +42,8 @@ public:
     void PrintStatistics(std::ostream &outStream);
 
     const double GetMeanSquaredError();
+    const double GetMeanAbsoluteDeviation();
+    const double GetMeanHuberLoss();
 
 protected:
     virtual void SetEngine(Engine *engine);
@@ -46,6 +51,11 @@ protected:
     Matrix<FLOAT> target;
     unsigned long nSample;
     double seSum;
+    double adSum;
+    double hlSum;
+
+    const LossType lossType;
+    const FLOAT delta; /* for LOSS_HUBER */
 };
 
 }


### PR DESCRIPTION
- Add FuncSignum to Engine & CudaKernels
- Multiply 1/2 to squared error in RegressProbe::EvaluateOnHost for
  consistency
- Existing code using RegressProbe is unaffected except for the 1/2
  factor in the displayed value of L2 loss; gradients are identical